### PR TITLE
[#57] Build multi-arch images

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -10,6 +10,9 @@
     <artifactId>quarkus-playpen-operator</artifactId>
     <name>Playpen Kubernetes Operator</name>
 
+    <properties>
+        <quarkus.docker.buildx.platform>linux/amd64,linux/arm64</quarkus.docker.buildx.platform>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -9,6 +9,11 @@
     </parent>
     <artifactId>playpen-proxy</artifactId>
     <name>Playpen Kubernetes Proxy</name>
+
+    <properties>
+        <quarkus.docker.buildx.platform>linux/amd64,linux/arm64</quarkus.docker.buildx.platform>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
supports `linux/am64` & `linux/arm64` for the operator and proxy images

This fixes #57.